### PR TITLE
Add check that termguicolors is also set

### DIFF
--- a/autoload/pinnacle.vim
+++ b/autoload/pinnacle.vim
@@ -186,7 +186,7 @@ function! pinnacle#extract_highlight(group) abort
   return l:original
 endfunction
 
-let s:prefix=has('gui') || has('termguicolors') ? 'gui' : 'cterm'
+let s:prefix=has('gui') || (has('termguicolors') && &termguicolors) ? 'gui' : 'cterm'
 
 function! pinnacle#extract_bg(group) abort
   return pinnacle#extract_component(a:group, 'bg')


### PR DESCRIPTION
When setting `s:prefix` also make sure that termguicolors is enabled.