### PR TITLE
fix: explicitly check vim.fn.has() value

### DIFF
--- a/lua/wincent/pinnacle.lua
+++ b/lua/wincent/pinnacle.lua
@@ -2,9 +2,9 @@ local pinnacle = {}
 
 local prefix = 'cterm'
 
-if vim.fn.has('gui') then
+if vim.fn.has('gui') == 1 then
   prefix = 'gui'
-elseif vim.fn.has('termguicolors') and vim.api.nvim_get_option('termguicolors') then
+elseif vim.fn.has('termguicolors') == 1 and vim.api.nvim_get_option('termguicolors') then
   prefix = 'gui'
 end
 


### PR DESCRIPTION
`luajit` considers zero as true in conditional tests, and `vim.fn.has({feature})` only return either 1 or 0 depends on whether or not `{feature}` is supported. Therefore, it's necessary to explicitly check the value of `vim.fn.has()` in condition tests, else it would always be true.